### PR TITLE
Pull default configs from shopstyle-node-common

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,6 @@
     "require-directory": "^2.1.1",
     "steve8708-typescript-register": "^1.1.5",
     "traverse": "^0.6.6",
-    "yargs": "^3.24.0"
+    "yargs": "^3.30.0"
   }
 }


### PR DESCRIPTION
This allows common components to set config values without requiring each
parent project to set the configs in that project. The default common configs
should be able to be overwritten by the parent project configs.