### PR TITLE
Fixes error with config key not in tree

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -259,10 +259,12 @@ export class Config {
     }
 
     // Loop over 'all' configs and merge them alphabetically
-    const keys = Object.keys(tree[all]).sort();
-    keys.forEach((key) => {
-      this.$merge(tree[all][key]);
-    });
+    if (typeof tree[all] === 'object') {
+      const keys = Object.keys(tree[all]).sort();
+      keys.forEach((key) => {
+        this.$merge(tree[all][key]);
+      });
+    }
 
     // Merge in env files
     const envDir = tree[options.envsDir];

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,9 +23,11 @@
         "!./node_modules/**/*"
     ],
     "files": [
-        "dist/config.d.ts",
-        "dist/src/config.d.ts",
-        "src/config.ts"
+        "./dist/src/config.d.ts",
+        "./src/config.ts"
     ],
-    "exclude": []
+    "exclude": [],
+    "atom": {
+        "rewriteTsconfig": true
+    }
 }


### PR DESCRIPTION
So the key `all` isn't in the tree: `[ 'env', 'local', 'private' ]`